### PR TITLE
Provide option to encode / decode structs in generic way 

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ iex> Eden.encode(%{a: 1, b: 2, c: 3})
 iex> Eden.encode({:a, 1})
 {:error, Protocol.UndefinedError}
 
+# can work transparently with Elixir structs (without tuple-values)
+iex> defmodule User, do: defstruct name: nil, age: nil
+
+iex> %User{age: 20, name: "Name"} |> Eden.encode!(preserve_structs: true) |> IO.inspect() |> Eden.decode!(preserve_structs: true)
+"#Elixir.User {:age 20, :name \"Name\"}"
+%User{age: 20, name: "Name"}
+
 iex> Eden.decode("{:a 1 :b 2}")
 {:ok, %{a: 1, b: 2}}
 
@@ -93,6 +100,10 @@ On one hand the decision to translate **edn** `keyword`s as Elixir `atom`s comes
 ### `vector`
 
 There is no constant lookup or nearly constant indexed data structure like **edn**'s `vector` other than the `:array` data structure implemented in one of Erlang's standard library modules. Until there is a better implementation for this `Eden` will use [`Array`](https://github.com/takscape/elixir-array), an Elixir wrapper library for Erlang's array.
+
+### Elixir structs
+
+To enable transparent encoding / decoding for your Elixir structs, pass the option: `preserve_structs: true` to both `Eden.encode` / `Eden.decode` functions.
 
 ## **edn** grammar
 

--- a/lib/eden.ex
+++ b/lib/eden.ex
@@ -59,9 +59,9 @@ defmodule Eden do
       {:error, Protocol.UndefinedError}
   """
   @spec encode(Encode.t()) :: {:ok, String.t()} | {:error, atom}
-  def encode(data) do
+  def encode(data, opts \\ []) do
     try do
-      {:ok, encode!(data)}
+      {:ok, encode!(data, opts)}
     rescue
       e -> {:error, e.__struct__}
     end
@@ -74,8 +74,8 @@ defmodule Eden do
   Returns the function result otherwise.
   """
   @spec encode!(Encode.t()) :: String.t()
-  def encode!(data) do
-    Encode.encode(data)
+  def encode!(data, opts \\ []) do
+    Encode.encode(data, opts)
   end
 
   @doc """

--- a/lib/eden.ex
+++ b/lib/eden.ex
@@ -124,7 +124,7 @@ defmodule Eden do
   def decode!(input, opts \\ []) do
     tree = parse(input, location: true)
     handlers = Map.merge(@default_handlers, opts[:handlers] || %{})
-    opts = [handlers: handlers]
+    opts = opts |> Keyword.put(:handlers, handlers)
 
     case Decode.decode(tree, opts) do
       [] -> raise Ex.EmptyInputError, input

--- a/lib/eden.ex
+++ b/lib/eden.ex
@@ -10,7 +10,11 @@ defmodule Eden do
   alias Eden.Decode
   alias Eden.Exception, as: Ex
 
-  @default_handlers %{"inst" => &Eden.Tag.inst/1, "uuid" => &Eden.Tag.uuid/1, "date" => &Eden.Tag.date/1}
+  @default_handlers %{
+    "inst" => &Eden.Tag.inst/1,
+    "uuid" => &Eden.Tag.uuid/1,
+    "date" => &Eden.Tag.date/1
+  }
 
   @doc """
   Encodes an *Elixir* term that implements the `Eden.Encode` protocol.

--- a/lib/eden/decode.ex
+++ b/lib/eden/decode.ex
@@ -109,7 +109,7 @@ defmodule Eden.Decode do
   end
 
   defp to_struct(tag = %Tag{name: name, value: value}) do
-    module = String.to_atom(name)
+    module = String.to_existing_atom(name)
 
     case Code.ensure_compiled(module) do
       {:module, _} -> struct(module, value)

--- a/lib/eden/decode.ex
+++ b/lib/eden/decode.ex
@@ -96,7 +96,8 @@ defmodule Eden.Decode do
   def decode(%Node{type: :tag, value: name, children: [child]}, opts) do
     case Map.get(opts[:handlers], name) do
       nil ->
-        %Tag{name: name, value: decode(child, opts)}
+        tag = %Tag{name: name, value: decode(child, opts)}
+        if opts[:preserve_structs], do: to_struct(tag), else: tag
 
       handler ->
         handler.(decode(child, opts))
@@ -105,5 +106,14 @@ defmodule Eden.Decode do
 
   def decode(%Node{type: type}, _opts) do
     raise "Unrecognized node type: #{inspect(type)}"
+  end
+
+  defp to_struct(tag = %Tag{name: name, value: value}) do
+    module = String.to_atom(name)
+
+    case Code.ensure_compiled(module) do
+      {:module, _} -> struct(module, value)
+      _ -> tag
+    end
   end
 end

--- a/lib/eden/encode.ex
+++ b/lib/eden/encode.ex
@@ -90,7 +90,7 @@ end
 defimpl Encode, for: MapSet do
   def encode(set, opts) do
     set
-    |> Enum.map(fn(x)-> Encode.encode(x, opts) end)
+    |> Enum.map(fn x -> Encode.encode(x, opts) end)
     |> Enum.join(", ")
     |> Utils.wrap("#\{", "}")
   end
@@ -126,7 +126,7 @@ end
 defimpl Encode, for: Any do
   def encode(struct, opts) when is_map(struct) do
     case opts[:preserve_structs] do
-      true -> to_tag_struct(struct, opts)
+      true -> to_tag_struct(struct)
       _ -> to_plain_map(struct)
     end
     |> Encode.encode(opts)
@@ -136,7 +136,7 @@ defimpl Encode, for: Any do
     raise %Protocol.UndefinedError{protocol: Encode, value: value}
   end
 
-  defp to_tag_struct(struct, opts) do
+  defp to_tag_struct(struct) do
     Eden.Tag.new(struct.__struct__, Map.from_struct(struct))
   end
 

--- a/lib/eden/encode.ex
+++ b/lib/eden/encode.ex
@@ -9,7 +9,7 @@ defprotocol Eden.Encode do
   @fallback_to_any true
 
   @spec encode(any) :: String.t()
-  def encode(value)
+  def encode(value, _opts \\ [])
 end
 
 defmodule Eden.Encode.Utils do
@@ -19,76 +19,76 @@ defmodule Eden.Encode.Utils do
 end
 
 defimpl Encode, for: Atom do
-  def encode(atom) when atom in [nil, true, false] do
+  def encode(atom, _opts) when atom in [nil, true, false] do
     Atom.to_string(atom)
   end
 
-  def encode(atom) do
+  def encode(atom, _opts) do
     ":" <> Atom.to_string(atom)
   end
 end
 
 defimpl Encode, for: Symbol do
-  def encode(symbol) do
+  def encode(symbol, _opts) do
     symbol.name
   end
 end
 
 defimpl Encode, for: BitString do
-  def encode(string) do
+  def encode(string, _opts) do
     "\"#{string}\""
   end
 end
 
 defimpl Encode, for: Character do
-  def encode(char) do
+  def encode(char, _opts) do
     "\\#{char.char}"
   end
 end
 
 defimpl Encode, for: Integer do
-  def encode(int) do
+  def encode(int, _opts) do
     "#{inspect(int)}"
   end
 end
 
 defimpl Encode, for: Float do
-  def encode(float) do
+  def encode(float, _opts) do
     "#{inspect(float)}"
   end
 end
 
 defimpl Encode, for: List do
-  def encode(list) do
+  def encode(list, opts) do
     list
-    |> Enum.map(&Encode.encode/1)
+    |> Enum.map(fn x -> Encode.encode(x, opts) end)
     |> Enum.join(", ")
     |> Utils.wrap("(", ")")
   end
 end
 
 defimpl Encode, for: Array do
-  def encode(array) do
+  def encode(array, opts) do
     array
     |> Array.to_list()
-    |> Enum.map(&Encode.encode/1)
+    |> Enum.map(fn x -> Encode.encode(x, opts) end)
     |> Enum.join(", ")
     |> Utils.wrap("[", "]")
   end
 end
 
 defimpl Encode, for: Map do
-  def encode(map) do
+  def encode(map, opts) do
     map
     |> Map.to_list()
-    |> Enum.map(fn {k, v} -> Encode.encode(k) <> " " <> Encode.encode(v) end)
+    |> Enum.map(fn {k, v} -> Encode.encode(k, opts) <> " " <> Encode.encode(v, opts) end)
     |> Enum.join(", ")
     |> Utils.wrap("{", "}")
   end
 end
 
 defimpl Encode, for: MapSet do
-  def encode(set) do
+  def encode(set, _opts) do
     set
     |> Enum.map(&Encode.encode/1)
     |> Enum.join(", ")
@@ -97,38 +97,50 @@ defimpl Encode, for: MapSet do
 end
 
 defimpl Encode, for: Tag do
-  def encode(tag) do
+  def encode(tag, _opts) do
     value = Encode.encode(tag.value)
     "##{tag.name} #{value}"
   end
 end
 
 defimpl Encode, for: UUID do
-  def encode(uuid) do
+  def encode(uuid, _opts) do
     Encode.encode(Tag.new("uuid", uuid.value))
   end
 end
 
 defimpl Encode, for: DateTime do
-  def encode(datetime) do
+  def encode(datetime, _opts) do
     value = DateTime.to_string(datetime) |> String.replace(" ", "T")
     Encode.encode(Tag.new("inst", value))
   end
 end
 
 defimpl Encode, for: Date do
-  def encode(date) do
+  def encode(date, _opts) do
     value = Date.to_iso8601(date)
     Encode.encode(Tag.new("date", value))
   end
 end
 
 defimpl Encode, for: Any do
-  def encode(struct) when is_map(struct) do
-    Encode.encode(Map.from_struct(struct))
+  def encode(struct, opts) when is_map(struct) do
+    case opts[:preserve_structs] do
+      true -> to_tag_struct(struct, opts)
+      _ -> to_plain_map(struct)
+    end
+    |> Encode.encode()
   end
 
-  def encode(value) do
+  def encode(value, _opts) do
     raise %Protocol.UndefinedError{protocol: Encode, value: value}
+  end
+
+  defp to_tag_struct(struct, opts) do
+    Eden.Tag.new(struct.__struct__, Encode.encode(Map.from_struct(struct), opts))
+  end
+
+  defp to_plain_map(struct) do
+    Map.from_struct(struct)
   end
 end

--- a/lib/eden/encode.ex
+++ b/lib/eden/encode.ex
@@ -97,8 +97,8 @@ defimpl Encode, for: MapSet do
 end
 
 defimpl Encode, for: Tag do
-  def encode(tag, _opts) do
-    value = Encode.encode(tag.value)
+  def encode(tag, opts) do
+    value = Encode.encode(tag.value, opts)
     "##{tag.name} #{value}"
   end
 end
@@ -137,7 +137,7 @@ defimpl Encode, for: Any do
   end
 
   defp to_tag_struct(struct, opts) do
-    Eden.Tag.new(struct.__struct__, Encode.encode(Map.from_struct(struct), opts))
+    Eden.Tag.new(struct.__struct__, Map.from_struct(struct))
   end
 
   defp to_plain_map(struct) do

--- a/lib/eden/encode.ex
+++ b/lib/eden/encode.ex
@@ -88,9 +88,9 @@ defimpl Encode, for: Map do
 end
 
 defimpl Encode, for: MapSet do
-  def encode(set, _opts) do
+  def encode(set, opts) do
     set
-    |> Enum.map(&Encode.encode/1)
+    |> Enum.map(fn(x)-> Encode.encode(x, opts) end)
     |> Enum.join(", ")
     |> Utils.wrap("#\{", "}")
   end
@@ -129,7 +129,7 @@ defimpl Encode, for: Any do
       true -> to_tag_struct(struct, opts)
       _ -> to_plain_map(struct)
     end
-    |> Encode.encode()
+    |> Encode.encode(opts)
   end
 
   def encode(value, _opts) do

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
   "array": {:git, "https://github.com/blogscot/elixir-array.git", "d829d4131a6dea1aba5a935b89daa32269944545", []},
-  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.4.3", "364ca2e9710f6bff494117dbbd53880d84bebb692dafc3a78eb50aa3183f2bfd", [:mix], [], "hexpm", "8cf8a291ebf1c7b9539e3cddb19e9cef066c2441b1640f13c34c1d3cfc825fec"},
+  "ex_doc": {:hex, :ex_doc, "0.21.2", "caca5bc28ed7b3bdc0b662f8afe2bee1eedb5c3cf7b322feeeb7c6ebbde089d6", [:mix], [{:earmark, "~> 1.3.3 or ~> 1.4", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "f1155337ae17ff7a1255217b4c1ceefcd1860b7ceb1a1874031e7a861b052e39"},
+  "makeup": {:hex, :makeup, "1.0.0", "671df94cf5a594b739ce03b0d0316aa64312cee2574b6a44becb83cd90fb05dc", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "a10c6eb62cca416019663129699769f0c2ccf39428b3bb3c0cb38c718a0c186d"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.14.0", "cf8b7c66ad1cff4c14679698d532f0b5d45a3968ffbcbfd590339cb57742f1ae", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "d4b316c7222a85bbaa2fd7c6e90e37e953257ad196dc229505137c5e505e9eff"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.3", "def21c10a9ed70ce22754fdeea0810dafd53c2db3219a0cd54cf5526377af1c6", [:mix], [], "hexpm", "589b5af56f4afca65217a1f3eb3fee7e79b09c40c742fddc1c312b3ac0b3399f"},
 }

--- a/test/eden_test.exs
+++ b/test/eden_test.exs
@@ -81,6 +81,28 @@ defmodule EdenTest do
       handlers = %{"custom/tag" => &custom_tag_handler/1}
       assert decode!("#custom/tag (1 2 3)", handlers: handlers) == [:a, :b, :c]
     end
+
+    defmodule StructDec1 do
+      defstruct a: "", b: 0
+    end
+
+    defmodule StructDec2 do
+      defstruct nested: []
+
+      def new() do
+        %StructDec2{nested: [%StructDec1{a: "1"}, %StructDec1{a: "2"}]}
+      end
+    end
+
+    test "struct - with preserve_structs: true" do
+      res = StructDec2.new() |> encode!(preserve_structs: true) |> decode!(preserve_structs: true)
+      assert res == StructDec2.new()
+    end
+
+    test "struct - with preserve_structs: false" do
+      res = StructDec2.new() |> encode!(preserve_structs: false) |> decode!(preserve_structs: false)
+      assert res == %{nested: [%{a: "1", b: 0}, %{a: "2", b: 0}]}
+    end
   end
 
   describe "encode" do

--- a/test/eden_test.exs
+++ b/test/eden_test.exs
@@ -161,25 +161,25 @@ defmodule EdenTest do
       assert encode!(some_tag) == "#custom/tag :joni"
     end
 
-    defmodule Struct1 do
+    defmodule StructEnc1 do
       defstruct a: "", b: 0
     end
 
-    defmodule Struct2 do
+    defmodule StructEnc2 do
       defstruct nested: []
 
       def new() do
-        %Struct2{nested: [%Struct1{a: "1"}, %Struct1{a: "2"}]}
+        %StructEnc2{nested: [%StructEnc1{a: "1"}, %StructEnc1{a: "2"}]}
       end
     end
 
     test "struct" do
       preserved =
-        "#Elixir.EdenTest.Struct2 {:nested (#Elixir.EdenTest.Struct1 {:a \"1\", :b 0}, #Elixir.EdenTest.Struct1 {:a \"2\", :b 0})}"
+        "#Elixir.EdenTest.StructEnc2 {:nested (#Elixir.EdenTest.StructEnc1 {:a \"1\", :b 0}, #Elixir.EdenTest.StructEnc1 {:a \"2\", :b 0})}"
 
       plain = "{:nested ({:a \"1\", :b 0}, {:a \"2\", :b 0})}"
-      assert encode!(Struct2.new(), preserve_structs: true) == preserved
-      assert encode!(Struct2.new(), preserve_structs: false) == plain
+      assert encode!(StructEnc2.new(), preserve_structs: true) == preserved
+      assert encode!(StructEnc2.new(), preserve_structs: false) == plain
     end
 
     test "fallback to Any" do

--- a/test/eden_test.exs
+++ b/test/eden_test.exs
@@ -9,157 +9,157 @@ defmodule EdenTest do
 
   ## Decode
 
-  test "Decode Empty Input" do
-    e = %Ex.EmptyInputError{}
-    assert decode("") == {:error, e.__struct__}
+  describe "decode" do
+    test "empty" do
+      e = %Ex.EmptyInputError{}
+      assert decode("") == {:error, e.__struct__}
 
-    assert_raise Ex.EmptyInputError, fn ->
-      decode!("")
+      assert_raise Ex.EmptyInputError, fn ->
+        decode!("")
+      end
+    end
+
+    test "literals" do
+      assert decode!("nil") == nil
+      assert decode!("true") == true
+      assert decode!("false") == false
+      assert decode!("false false") == [false, false]
+
+      assert decode!("\"hello world!\"") == "hello world!"
+      assert decode!("\"hello \\n world!\"") == "hello \n world!"
+
+      assert decode!("\\n") == %Character{char: "n"}
+      assert decode!("\\z") == %Character{char: "z"}
+
+      assert decode!("a-symbol") == %Symbol{name: "a-symbol"}
+      assert decode!(":the-keyword") == :"the-keyword"
+
+      assert decode!("42") == 42
+      assert decode!("42N") == 42
+
+      assert decode!("42.0") == 42.0
+      assert decode!("42M") == 42.0
+      assert decode!("42.0e3") == 42000.0
+      assert decode!("42e-3") == 0.042
+      assert decode!("42E-1") == 4.2
+      assert decode!("42.01E+1") == 420.1
+    end
+
+    test "list" do
+      assert decode!("(1 :a 42.0)") == [1, :a, 42.0]
+    end
+
+    test "vector" do
+      array = Array.from_list([1, :a, 42.0])
+      assert decode!("[1 :a 42.0]") == array
+    end
+
+    test "map" do
+      map = %{name: "John", age: 42}
+      assert decode!("{:name \"John\" :age 42}") == map
+
+      assert_raise Ex.OddExpressionCountError, fn ->
+        decode!("{:name \"John\" :age}")
+      end
+    end
+
+    test "set" do
+      set = Enum.into([:name, "John", :age, 42], MapSet.new())
+      assert decode!("#\{:name \"John\" :age 42}") == set
+    end
+
+    test "tag" do
+      date = parse_datetime("1985-04-12T23:20:50.52Z")
+      assert decode!("#inst \"1985-04-12T23:20:50.52Z\"") == date
+
+      assert decode!("#uuid \"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\"") == %UUID{
+               value: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
+             }
+
+      assert decode!(~s{#date "2019-12-31"}) == ~D[2019-12-31]
+      assert decode!("#custom/tag (1 2 3)") == %Tag{name: "custom/tag", value: [1, 2, 3]}
+      handlers = %{"custom/tag" => &custom_tag_handler/1}
+      assert decode!("#custom/tag (1 2 3)", handlers: handlers) == [:a, :b, :c]
     end
   end
 
-  test "Decode Literals" do
-    assert decode!("nil") == nil
-    assert decode!("true") == true
-    assert decode!("false") == false
-    assert decode!("false false") == [false, false]
+  describe "encode" do
+    test "literals" do
+      assert encode!(nil) == "nil"
+      assert encode!(true) == "true"
+      assert encode!(false) == "false"
 
-    assert decode!("\"hello world!\"") == "hello world!"
-    assert decode!("\"hello \\n world!\"") == "hello \n world!"
+      assert encode!("hello world!") == "\"hello world!\""
+      assert encode!("hello \n world!") == "\"hello \n world!\""
 
-    assert decode!("\\n") == %Character{char: "n"}
-    assert decode!("\\z") == %Character{char: "z"}
+      assert encode!(Character.new("n")) == "\\n"
+      assert encode!(Character.new("z")) == "\\z"
 
-    assert decode!("a-symbol") == %Symbol{name: "a-symbol"}
-    assert decode!(":the-keyword") == :"the-keyword"
+      assert encode!(Symbol.new("a-symbol")) == "a-symbol"
+      assert encode!(:"the-keyword") == ":the-keyword"
 
-    assert decode!("42") == 42
-    assert decode!("42N") == 42
+      assert encode!(42) == "42"
 
-    assert decode!("42.0") == 42.0
-    assert decode!("42M") == 42.0
-    assert decode!("42.0e3") == 42000.0
-    assert decode!("42e-3") == 0.042
-    assert decode!("42E-1") == 4.2
-    assert decode!("42.01E+1") == 420.1
-  end
-
-  test "Decode List" do
-    assert decode!("(1 :a 42.0)") == [1, :a, 42.0]
-  end
-
-  test "Decode Vector" do
-    array = Array.from_list([1, :a, 42.0])
-    assert decode!("[1 :a 42.0]") == array
-  end
-
-  test "Decode Map" do
-    map = %{name: "John", age: 42}
-    assert decode!("{:name \"John\" :age 42}") == map
-
-    assert_raise Ex.OddExpressionCountError, fn ->
-      decode!("{:name \"John\" :age}")
-    end
-  end
-
-  test "Decode Set" do
-    set = Enum.into([:name, "John", :age, 42], MapSet.new())
-    assert decode!("#\{:name \"John\" :age 42}") == set
-  end
-
-  test "Decode Tag" do
-    date = parse_datetime("1985-04-12T23:20:50.52Z")
-    assert decode!("#inst \"1985-04-12T23:20:50.52Z\"") == date
-
-    assert decode!("#uuid \"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\"") == %UUID{
-             value: "f81d4fae-7dec-11d0-a765-00a0c91e6bf6"
-           }
-
-    assert decode!(~s{#date "2019-12-31"}) == ~D[2019-12-31]
-
-    assert decode!("#custom/tag (1 2 3)") == %Tag{name: "custom/tag", value: [1, 2, 3]}
-    handlers = %{"custom/tag" => &custom_tag_handler/1}
-    assert decode!("#custom/tag (1 2 3)", handlers: handlers) == [:a, :b, :c]
-  end
-
-  ## Encode
-
-  test "Encode Literals" do
-    assert encode!(nil) == "nil"
-    assert encode!(true) == "true"
-    assert encode!(false) == "false"
-
-    assert encode!("hello world!") == "\"hello world!\""
-    assert encode!("hello \n world!") == "\"hello \n world!\""
-
-    assert encode!(Character.new("n")) == "\\n"
-    assert encode!(Character.new("z")) == "\\z"
-
-    assert encode!(Symbol.new("a-symbol")) == "a-symbol"
-    assert encode!(:"the-keyword") == ":the-keyword"
-
-    assert encode!(42) == "42"
-
-    assert encode!(42.0) == "42.0"
-    assert encode!(42.0e3) == "4.2e4"
-    assert encode!(42.0e-3) == "0.042"
-    assert encode!(42.0e-1) == "4.2"
-    assert encode!(42.01e+1) == "420.1"
-  end
-
-  test "Encode List" do
-    assert encode!([1, :a, 42.0]) == "(1, :a, 42.0)"
-  end
-
-  test "Encode Vector" do
-    array = Array.from_list([1, :a, 42.0])
-    assert encode!(array) == "[1, :a, 42.0]"
-  end
-
-  test "Encode Map" do
-    map = %{name: "John", age: 42}
-    assert encode!(map) == "{:age 42, :name \"John\"}"
-  end
-
-  test "Encode Set" do
-    set = Enum.into([:name, "John", :age, 42], MapSet.new())
-    assert encode!(set) == "\#{42, :age, :name, \"John\"}"
-  end
-
-  test "Encode Tag" do
-    date = parse_datetime("1985-04-12T23:20:50.52Z")
-    assert encode!(date) == "#inst \"1985-04-12T23:20:50.52Z\""
-    uuid = UUID.new("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
-    assert encode!(uuid) == "#uuid \"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\""
-
-    date = ~D[2019-12-31]
-    assert encode!(date) == "#date \"2019-12-31\""
-
-
-    some_tag = Tag.new("custom/tag", :joni)
-    assert encode!(some_tag) == "#custom/tag :joni"
-  end
-
-  test "Encode Fallback to Any" do
-    node = %Eden.Parser.Node{}
-    map = Map.from_struct(node)
-    assert encode!(node) == encode!(map)
-  end
-
-  test "Encode Unknown Type" do
-    e = %Protocol.UndefinedError{}
-    assert encode(self()) == {:error, e.__struct__}
-
-    assert_raise Protocol.UndefinedError, fn ->
-      encode!(self())
+      assert encode!(42.0) == "42.0"
+      assert encode!(42.0e3) == "4.2e4"
+      assert encode!(42.0e-3) == "0.042"
+      assert encode!(42.0e-1) == "4.2"
+      assert encode!(42.01e+1) == "420.1"
     end
 
-    try do
-      encode!(self())
-    rescue
-      e in Protocol.UndefinedError ->
-        assert e.protocol == Eden.Encode
-        assert e.value == self()
+    test "list" do
+      assert encode!([1, :a, 42.0]) == "(1, :a, 42.0)"
+    end
+
+    test "vector" do
+      array = Array.from_list([1, :a, 42.0])
+      assert encode!(array) == "[1, :a, 42.0]"
+    end
+
+    test "map" do
+      map = %{name: "John", age: 42}
+      assert encode!(map) == "{:age 42, :name \"John\"}"
+    end
+
+    test "set" do
+      set = Enum.into([:name, "John", :age, 42], MapSet.new())
+      assert encode!(set) == "\#{42, :age, :name, \"John\"}"
+    end
+
+    test "tag" do
+      date = parse_datetime("1985-04-12T23:20:50.52Z")
+      assert encode!(date) == "#inst \"1985-04-12T23:20:50.52Z\""
+      uuid = UUID.new("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+      assert encode!(uuid) == "#uuid \"f81d4fae-7dec-11d0-a765-00a0c91e6bf6\""
+
+      date = ~D[2019-12-31]
+      assert encode!(date) == "#date \"2019-12-31\""
+
+      some_tag = Tag.new("custom/tag", :joni)
+      assert encode!(some_tag) == "#custom/tag :joni"
+    end
+
+    test "fallback to Any" do
+      node = %Eden.Parser.Node{}
+      map = Map.from_struct(node)
+      assert encode!(node) == encode!(map)
+    end
+
+    test "unknown type" do
+      e = %Protocol.UndefinedError{}
+      assert encode(self()) == {:error, e.__struct__}
+
+      assert_raise Protocol.UndefinedError, fn ->
+        encode!(self())
+      end
+
+      try do
+        encode!(self())
+      rescue
+        e in Protocol.UndefinedError ->
+          assert e.protocol == Eden.Encode
+          assert e.value == self()
+      end
     end
   end
 

--- a/test/eden_test.exs
+++ b/test/eden_test.exs
@@ -153,7 +153,7 @@ defmodule EdenTest do
 
     test "struct" do
       preserved =
-        "#Elixir.EdenTest.Struct2 \"{:nested (#Elixir.EdenTest.Struct1 \"{:a \"1\", :b 0}\", #Elixir.EdenTest.Struct1 \"{:a \"2\", :b 0}\")}\""
+        "#Elixir.EdenTest.Struct2 {:nested (#Elixir.EdenTest.Struct1 {:a \"1\", :b 0}, #Elixir.EdenTest.Struct1 {:a \"2\", :b 0})}"
 
       plain = "{:nested ({:a \"1\", :b 0}, {:a \"2\", :b 0})}"
       assert encode!(Struct2.new(), preserve_structs: true) == preserved

--- a/test/eden_test.exs
+++ b/test/eden_test.exs
@@ -139,6 +139,27 @@ defmodule EdenTest do
       assert encode!(some_tag) == "#custom/tag :joni"
     end
 
+    defmodule Struct1 do
+      defstruct a: "", b: 0
+    end
+
+    defmodule Struct2 do
+      defstruct nested: []
+
+      def new() do
+        %Struct2{nested: [%Struct1{a: "1"}, %Struct1{a: "2"}]}
+      end
+    end
+
+    test "struct" do
+      preserved =
+        "#Elixir.EdenTest.Struct2 \"{:nested (#Elixir.EdenTest.Struct1 \"{:a \"1\", :b 0}\", #Elixir.EdenTest.Struct1 \"{:a \"2\", :b 0}\")}\""
+
+      plain = "{:nested ({:a \"1\", :b 0}, {:a \"2\", :b 0})}"
+      assert encode!(Struct2.new(), preserve_structs: true) == preserved
+      assert encode!(Struct2.new(), preserve_structs: false) == plain
+    end
+
     test "fallback to Any" do
       node = %Eden.Parser.Node{}
       map = Map.from_struct(node)


### PR DESCRIPTION
## Problem: 
Encoding / Decoding structs currently is rather cumbersome with Eden. 

## Solution: 
Allow `preserve_structs: true` option that will turn your structs automatically into tagged elements that can be decoded back into Elixir structs without much pain. 